### PR TITLE
django signals & slack notifications for invitations added

### DIFF
--- a/apps/accounts/forms/auth.py
+++ b/apps/accounts/forms/auth.py
@@ -1,5 +1,6 @@
 # Python Standard Library Imports
 
+
 # Third Party (PyPI) Imports
 import rollbar
 
@@ -178,6 +179,7 @@ class UserRegistrationForm(UserCreationForm):
                     email_sender=email_sender
                 )
             return user
+        
 
         from htk.apps.accounts.locks import UserEmailRegistrationLock
         email = self.email

--- a/apps/invitations/services.py
+++ b/apps/invitations/services.py
@@ -27,11 +27,10 @@ class InvitationsService(HtkBaseService):
 
                 if htk_setting('HTK_SLACK_NOTIFICATIONS_ENABLED'):
                     from htk.utils.notifications import slack_notify
-
                     msg = '*%s* has signed up for %s as a result of an invitation from *%s <%s>* (Campaign: `%s` - sent %s).' % (
                         email,
                         get_site_name(),
-                        invitation.invited_by.profile.display_name,
+                        invitation.invited_by.profile.display_name, #first name last name
                         invitation.invited_by.email,
                         invitation.campaign or 'None',
                         invitation.get_relative_time(),
@@ -64,3 +63,4 @@ class InvitationsService(HtkBaseService):
             if q.exists():
                 invitation = q.first()
                 invitation.complete(user)
+                

--- a/apps/organizations/emailers.py
+++ b/apps/organizations/emailers.py
@@ -32,3 +32,15 @@ def send_invitation_email(request, invitation, early_access_code=None):
         template=htk_setting('HTK_ORGANIZATION_INVITATION_EMAIL_TEMPLATE_NAME'),
         context=context,
     )
+    if send_email:
+        from htk.utils.notifications import slack_notify
+        msg = '*%s* (%s<%s>) has sent an invitation for Organization (<%s>) to email %s' % (
+            invitation.invited_by.profile.display_name, #first name last name
+            invitation.organization.name, 
+            invitation.invited_by.email,
+            invitation_url,
+            invitation.email,
+        )
+        slack_notify(msg)
+        'Firstname Lastname (username<profileurl>) has sent an invitation for Organization (<organizationurl>) to <email>'
+

--- a/lib/slack/constants/defaults.py
+++ b/lib/slack/constants/defaults.py
@@ -67,6 +67,10 @@ HTK_SLACK_NOTIFICATION_CHANNELS = {
 }
 HTK_SLACK_DEBUG_CHANNEL = '#test'
 
+HTK_SLACK_DEBUG_CHANNELS = {
+    'test': '#test',
+    'debug': '#alerts-p5-debug'
+}
 
 ##
 # url names (routes)

--- a/utils/notifications.py
+++ b/utils/notifications.py
@@ -58,7 +58,7 @@ def slack_notify(message, level=None):
     try:
         channels = htk_setting('HTK_SLACK_NOTIFICATION_CHANNELS')
         default_level = (
-            'debug' if (settings.ENV_DEV or settings.TEST) else 'info'
+            'info' if (settings.ENV_DEV or settings.TEST) else 'debug'
         )
         level = level if level in channels else default_level
         channel = channels.get(level, htk_setting('HTK_SLACK_DEBUG_CHANNEL'))


### PR DESCRIPTION
- Connect a Django signal and display a slack alert whenever an invitation is sent and accepted/declined
- Customized the Slack message to display what is shown on the Trello ticket

## Motivation and Context

- The change was made in order to be notified of the new users activity. Specifically it shows how new users are created specifically through invitations. 

## How Has This Been Tested?
The tests were manually done. New users were created and invited by myself. Invitations were accepted/declined and these changes were reflected in the '#test' channel in slack. 

- [ ] Added unit tests [...]
- [x] Clicked around the app locally

## Screenshots and Screen Captures (if appropriate):

<img width="904" alt="Screenshot 2023-10-13 at 9 46 19 AM" src="https://github.com/aweandreverence/maskil-django/assets/116114507/678f7470-77eb-4f18-87ea-dbd1051dea0a">

<img width="910" alt="Screenshot 2023-10-13 at 9 46 54 AM" src="https://github.com/aweandreverence/maskil-django/assets/116114507/304aebd4-fb35-4a47-8528-e622d70f38db">
