### PR TITLE
feat: configurable Slack display name for changelog release announce

### DIFF
--- a/apps/changelog/classes/change_log.py
+++ b/apps/changelog/classes/change_log.py
@@ -22,6 +22,7 @@ class ChangeLog(
         changelog_file_name,
         slack_announce=False,
         slack_channel=None,
+        slack_username=None,
         slack_webhook_url=None,
         web_url=None,
     ):
@@ -93,6 +94,7 @@ class ChangeLog(
             slack_webhook_call(
                 webhook_url=slack_webhook_url,
                 channel=slack_channel,
+                username=slack_username,
                 text=slack_message,
                 unfurl_links=False,
             )

--- a/apps/changelog/constants/defaults.py
+++ b/apps/changelog/constants/defaults.py
@@ -1,5 +1,8 @@
 HTK_CHANGELOG_FILE_PATH = 'CHANGELOG.md'
 HTK_CHANGELOG_SLACK_CHANNEL_RELEASES = '#release-notes'
+# Optional Slack display name (username) for the release-notes post. None ->
+# the webhook's configured default name.
+HTK_CHANGELOG_SLACK_USERNAME = None
 HTK_CHANGELOG_VIEW_IN_WEB_URL_NAME = None
 HTK_CHANGELOG_VIEW_IN_WEB_URL = None
 

--- a/apps/changelog/management/commands/changelog.py
+++ b/apps/changelog/management/commands/changelog.py
@@ -59,6 +59,7 @@ class Command(BaseCommand):
         silent = kwargs.get('silent', False)
         changelog_file_name = htk_setting('HTK_CHANGELOG_FILE_PATH')
         slack_channel = htk_setting('HTK_CHANGELOG_SLACK_CHANNEL_RELEASES')
+        slack_username = htk_setting('HTK_CHANGELOG_SLACK_USERNAME')
         web_url_name = htk_setting('HTK_CHANGELOG_VIEW_IN_WEB_URL_NAME')
         web_url = htk_setting('HTK_CHANGELOG_VIEW_IN_WEB_URL')
 
@@ -79,6 +80,7 @@ class Command(BaseCommand):
             changelog_file_name=changelog_file_name,
             slack_announce=slack_announce,
             slack_channel=slack_channel,
+            slack_username=slack_username,
             web_url=web_url,
         )
 


### PR DESCRIPTION
Adds `HTK_CHANGELOG_SLACK_USERNAME` so each app can set the **display name (sender)** of its `manage.py changelog --slack-announce` post.

## Why
`webhook_call` already accepts `username`, but the changelog path never passed it, so the release-notes post always used the webhook's configured default name. Apps that share a webhook (or want a per-app announcer name) couldn't override it.

## Change
- `constants/defaults.py`: `HTK_CHANGELOG_SLACK_USERNAME = None`.
- `management/commands/changelog.py`: read the setting, pass to `write_changelog`.
- `classes/change_log.py`: `write_changelog(..., slack_username=None)` → forwards to `webhook_call(username=...)`.

Default `None` preserves current behavior (uses the webhook's configured name). Consumed by accounts to post as "Awe and Reverence Accounts App".

🤖 Generated with [Claude Code](https://claude.com/claude-code)